### PR TITLE
Use Godot's Vulkan render device

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -5,7 +5,6 @@ openvr_dir = "lib/openvr/"
 
 # First, create a custom env for the shared library.
 module_env = env.Clone()
-from compat import isbasestring
 
 # Add library includes
 module_env.Append(CPPPATH=[

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -31,5 +31,5 @@ void unregister_gdopenvr_types() {
 	if (new_interface == nullptr) {
 		return;
 	}
-	new_interface = nullptr;
+	new_interface.unref();
 }

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,6 +1,6 @@
 
 #include "register_types.h"
-#include "core/class_db.h"
+#include "core/object/class_db.h"
 #include "src/openvr/OpenVRInterface.h"
 #include "src/openvr/OpenVRAction.h"
 #include "src/openvr/OpenVRController.h"

--- a/src/openvr/OpenVRAction.h
+++ b/src/openvr/OpenVRAction.h
@@ -2,10 +2,10 @@
 #define OPENVR_ACTION_H
 
 #include "openvr_data.h"
-#include <scene/3d/spatial.h>
+#include <scene/3d/node_3d.h>
 
-class OpenVRAction : public Spatial {
-	GDCLASS(OpenVRAction, Spatial)
+class OpenVRAction : public Node3D {
+	GDCLASS(OpenVRAction, Node3D)
 
 private:
 	openvr_data *ovr;

--- a/src/openvr/OpenVRController.cpp
+++ b/src/openvr/OpenVRController.cpp
@@ -55,8 +55,8 @@ OpenVRController::~OpenVRController() {
 	}
 }
 
-PoolStringArray OpenVRController::get_button_actions() {
-	PoolStringArray actions;
+PackedStringArray OpenVRController::get_button_actions() {
+	PackedStringArray actions;
 
 	for (std::vector<input_action>::iterator it = button_actions.begin(); it != button_actions.end(); ++it) {
 		actions.push_back(it->name);
@@ -65,7 +65,7 @@ PoolStringArray OpenVRController::get_button_actions() {
 	return actions;
 }
 
-void OpenVRController::set_button_actions(PoolStringArray p_actions) {
+void OpenVRController::set_button_actions(PackedStringArray p_actions) {
 	// we're assuming this only gets set once so we can be a little careless and start anew
 	button_actions.clear();
 

--- a/src/openvr/OpenVRController.h
+++ b/src/openvr/OpenVRController.h
@@ -2,12 +2,12 @@
 #define OPENVR_CONTROLLER_H
 
 #include "openvr_data.h"
-#include <scene/3d/arvr_nodes.h>
+#include <scene/3d/xr_nodes.h>
 
 #include <vector>
 
-class OpenVRController : public ARVRController {
-	GDCLASS(OpenVRController, ARVRController)
+class OpenVRController : public XRController3D {
+	GDCLASS(OpenVRController, XRController3D)
 
 private:
 	openvr_data *ovr;
@@ -29,8 +29,8 @@ public:
 	OpenVRController();
 	~OpenVRController();
 
-	PoolStringArray get_button_actions();
-	void set_button_actions(PoolStringArray p_actions);
+	PackedStringArray get_button_actions();
+	void set_button_actions(PackedStringArray p_actions);
 
 	Vector2 get_analog(String p_action);
 	void trigger_haptic(String p_action, float p_duration, float p_frequency, float p_amplitude);

--- a/src/openvr/OpenVRHaptics.cpp
+++ b/src/openvr/OpenVRHaptics.cpp
@@ -1,4 +1,13 @@
 #include "OpenVRHaptics.h"
+#include <core/version.h>
+
+#if(VERSION_MAJOR) >= 4
+	#define TEXTURE_CLASS Texture2D
+	#define REAL_VARIANT Variant::FLOAT
+#else
+	#define TEXTURE_CLASS Texture
+	#define REAL_VARIANT Variant::REAL
+#endif
 
 void OpenVRHaptics::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_action"), &OpenVRHaptics::get_action);
@@ -11,15 +20,15 @@ void OpenVRHaptics::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_duration"), &OpenVRHaptics::get_duration);
 	ClassDB::bind_method(D_METHOD("set_duration"), &OpenVRHaptics::set_duration);
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "duration", PROPERTY_HINT_NONE), "set_duration", "get_duration");
+	ADD_PROPERTY(PropertyInfo(REAL_VARIANT, "duration", PROPERTY_HINT_NONE), "set_duration", "get_duration");
 
 	ClassDB::bind_method(D_METHOD("get_frequency"), &OpenVRHaptics::get_frequency);
 	ClassDB::bind_method(D_METHOD("set_frequency"), &OpenVRHaptics::set_frequency);
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "frequency", PROPERTY_HINT_NONE), "set_frequency", "get_frequency");
+	ADD_PROPERTY(PropertyInfo(REAL_VARIANT, "frequency", PROPERTY_HINT_NONE), "set_frequency", "get_frequency");
 
 	ClassDB::bind_method(D_METHOD("get_amplitude"), &OpenVRHaptics::get_amplitude);
 	ClassDB::bind_method(D_METHOD("set_amplitude"), &OpenVRHaptics::set_amplitude);
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "amplitude", PROPERTY_HINT_NONE), "set_amplitude", "get_amplitude");
+	ADD_PROPERTY(PropertyInfo(REAL_VARIANT, "amplitude", PROPERTY_HINT_NONE), "set_amplitude", "get_amplitude");
 
 	ClassDB::bind_method(D_METHOD("trigger_pulse"), &OpenVRHaptics::trigger_pulse);
 

--- a/src/openvr/OpenVRHaptics.h
+++ b/src/openvr/OpenVRHaptics.h
@@ -2,10 +2,10 @@
 #define OPENVR_HAPTICS_H
 
 #include "openvr_data.h"
-#include <scene/3d/spatial.h>
+#include <scene/3d/node_3d.h>
 
-class OpenVRHaptics : public Spatial {
-	GDCLASS(OpenVRHaptics, Spatial)
+class OpenVRHaptics : public Node3D {
+	GDCLASS(OpenVRHaptics, Node3D)
 
 private:
 	openvr_data *ovr;

--- a/src/openvr/OpenVRInterface.cpp
+++ b/src/openvr/OpenVRInterface.cpp
@@ -165,55 +165,6 @@ unsigned int OpenVRInterface::get_external_texture_for_eye(XRInterface::Eyes p_e
 	return 0;
 }
 
-void OpenVRInterface::commit_for_eye(XRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) {
-	// This function is responsible for outputting the final render buffer for
-	// each eye.
-	// p_screen_rect will only have a value when we're outputting to the main
-	// viewport.
-
-	// For an interface that must output to the main viewport (such as with mobile
-	// VR) we should give an error when p_screen_rect is not set
-	// For an interface that outputs to an external device we should render a copy
-	// of one of the eyes to the main viewport if p_screen_rect is set, and only
-	// output to the external device if not.
-
-	Rect2 screen_rect = p_screen_rect;
-	
-	if (p_eye == 1 && !screen_rect.has_no_area()) {
-		// blit as mono, attempt to keep our aspect ratio and center our render buffer
-		Vector2 render_size = get_render_targetsize();
-
-		float new_height = screen_rect.size.x * (render_size.y / render_size.x);
-		if (new_height > screen_rect.size.y) {
-			screen_rect.position.y = (0.5f * screen_rect.size.y) - (0.5f * new_height);
-			screen_rect.size.y = new_height;
-		} else {
-			float new_width = screen_rect.size.y * (render_size.x / render_size.y);
-
-			screen_rect.position.x = (0.5f * screen_rect.size.x) - (0.5f * new_width);
-			screen_rect.size.x = new_width;
-		}
-
-		blit(0, &p_render_target, &screen_rect);
-	}
-	
-	XRInterface::Eyes eye = (XRInterface::Eyes)p_eye;
-
-	if (eye == XRInterface::EYE_LEFT) {
-		screen_rect.size.x /= 2.0;
-	} else if (p_eye == XRInterface::EYE_RIGHT) {
-		screen_rect.size.x /= 2.0;
-		screen_rect.position.x += screen_rect.size.x;
-	}	
-	RendererCompositor::BlitToScreen blit;
-	blit.render_target = p_render_target;
-	blit.rect = Rect2i(screen_rect);
-	blit.eye = p_eye;
-	blit.vr = true;
-	RSG::rasterizer->prepare_for_blitting_render_targets();
-	RSG::rasterizer->blit_render_targets_to_screen(0, &blit, 1);
-}
-
 void OpenVRInterface::process() {
 	// this method gets called before every frame is rendered, here is where you
 	// should update tracking data, update controllers, etc.

--- a/src/openvr/OpenVRInterface.cpp
+++ b/src/openvr/OpenVRInterface.cpp
@@ -140,7 +140,7 @@ Transform OpenVRInterface::get_transform_for_eye(XRInterface::Eyes p_eye, const 
 void OpenVRInterface::fill_projection_for_eye(float *p_projection, int p_eye, float p_aspect, float p_z_near, float p_z_far) {
 	if (arvr_data->ovr->is_initialised()) {
 		vr::HmdMatrix44_t matrix = arvr_data->ovr->hmd->GetProjectionMatrix(
-				p_eye == 1 ? vr::Eye_Left : vr::Eye_Right, p_z_near, p_z_far);
+				p_eye == XRInterface::EYE_LEFT ? vr::Eye_Left : vr::Eye_Right, p_z_near, p_z_far);
 
 		int k = 0;
 		for (int i = 0; i < 4; i++) {

--- a/src/openvr/OpenVRInterface.h
+++ b/src/openvr/OpenVRInterface.h
@@ -1,7 +1,7 @@
 #ifndef GDOVR_ARVR_INTERFACE_H
 #define GDOVR_ARVR_INTERFACE_H
 
-#include <openvr.h>
+#include "modules/gdopenvr/lib/openvr/headers/openvr.h"
 #include <servers/xr_server.h>
 #include <servers/xr/xr_interface.h>
 #include <servers/xr/xr_positional_tracker.h>
@@ -31,8 +31,6 @@ class OpenVRInterface : public XRInterface {
 		openvr_data *ovr;
 		uint32_t width;
 		uint32_t height;
-
-		int texture_id;
 	} arvr_data_struct;
 
 	arvr_data_struct *arvr_data = NULL;
@@ -259,8 +257,8 @@ public:
 	void blit(int p_eye, RID *p_render_target, Rect2 *p_rect) {
 		// blits out our texture as is, handy for preview display of one of the eyes that is already rendered with lens distortion on an external HMD
 		XRInterface::Eyes eye = (XRInterface::Eyes)p_eye;
-		RID *render_target = (RID *)p_render_target;
-		Rect2 screen_rect = *(Rect2 *)p_rect;
+		RID *render_target = p_render_target;
+		Rect2 screen_rect = *p_rect;
 
 		if (eye == XRInterface::EYE_LEFT) {
 			screen_rect.size.x /= 2.0;
@@ -269,26 +267,11 @@ public:
 			screen_rect.position.x += screen_rect.size.x;
 		}
 
-		/* THIS BIT NEEDS REDONE
-		RSG::rasterizer->set_current_render_target(RID());
-		RSG::rasterizer->blit_render_target_to_screen(*render_target, screen_rect, 0);
-		*/
-
-	}
-
-	uint32_t get_texid(RID *p_render_target) {
-		// In order to send off our textures to display on our hardware we need the opengl texture ID instead of the render target RID
-		// This is a handy function to expose that.
-
-		// need to redo this
-
-	/*	RID *render_target = (RID *)p_render_target;
-
-		RID eye_texture = RSG::storage->render_target_get_texture(*render_target);
-		uint32_t texid = RS::get_singleton()->texture_get_texid(eye_texture);
-
-		return texid;*/
-		return 0;
+		RSG::rasterizer->prepare_for_blitting_render_targets();
+		RendererCompositor::BlitToScreen blit;
+		blit.render_target = *p_render_target;
+		blit.rect = Rect2i(*p_rect);
+		RSG::rasterizer->blit_render_targets_to_screen(0, &blit, 1);
 	}
 };
 

--- a/src/openvr/OpenVRInterface.h
+++ b/src/openvr/OpenVRInterface.h
@@ -2,24 +2,36 @@
 #define GDOVR_ARVR_INTERFACE_H
 
 #include <openvr.h>
-#include <servers/arvr/arvr_interface.h>
-#include <servers/visual/visual_server_globals.h>
-#include <servers/arvr/arvr_positional_tracker.h>
-#include <core/os/input.h>
-#include <servers/visual/visual_server_globals.h>
-#include <main/input_default.h>
+#include <servers/xr_server.h>
+#include <servers/xr/xr_interface.h>
+#include <servers/xr/xr_positional_tracker.h>
+#include <core/input/input.h>
 
 #include "openvr_data.h"
+#include <core/version.h>
 
-class OpenVRInterface : public ARVRInterface {
-	GDCLASS(OpenVRInterface, ARVRInterface);
+#if (VERSION_MAJOR) >= 4
+	#include "servers/rendering_server.h"
+	#include <servers/rendering/rendering_server_globals.h>
+
+	#define TEXTURE_CLASS Texture2D
+	#define REAL_VARIANT Variant::FLOAT
+#else
+	#include "servers/visual_server.h"
+	#include <servers/visual/visual_server_globals.h>
+
+	#define TEXTURE_CLASS Texture
+	#define REAL_VARIANT Variant::REAL
+#endif
+
+class OpenVRInterface : public XRInterface {
+	GDCLASS(OpenVRInterface, XRInterface);
 
 	typedef struct arvr_data_struct {
 		openvr_data *ovr;
 		uint32_t width;
 		uint32_t height;
 
-		int video_driver;
 		int texture_id;
 	} arvr_data_struct;
 
@@ -51,11 +63,11 @@ public:
 
 	Size2 get_render_targetsize() override; /* returns the recommended render target size per eye for this device */
 	bool is_stereo() override; /* returns true if this interface requires stereo rendering (for VR HMDs) or mono rendering (for mobile AR) */
-	Transform get_transform_for_eye(ARVRInterface::Eyes p_eye, const Transform &p_cam_transform) override; /* get each eyes camera transform, also implement EYE_MONO */
+	Transform get_transform_for_eye(XRInterface::Eyes p_eye, const Transform &p_cam_transform) override; /* get each eyes camera transform, also implement EYE_MONO */
 	void fill_projection_for_eye(float *p_projection, int p_eye, float p_aspect, float p_z_near, float p_z_far);
-	CameraMatrix get_projection_for_eye(ARVRInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) override; /* get each eyes projection matrix */
-	unsigned int get_external_texture_for_eye(ARVRInterface::Eyes p_eye) override; /* if applicable return external texture to render to */
-	void commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) override; /* output the left or right eye */
+	CameraMatrix get_projection_for_eye(XRInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) override; /* get each eyes projection matrix */
+	unsigned int get_external_texture_for_eye(XRInterface::Eyes p_eye) override; /* if applicable return external texture to render to */
+	void commit_for_eye(XRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) override; /* output the left or right eye */
 
 	void process() override;
 	void notification(int p_what) override;
@@ -77,7 +89,7 @@ public:
 	bool is_action_set_active(const String p_action_set) const;
 
 	bool play_area_available() const;
-	PoolVector3Array get_play_area() const;
+	PackedVector3Array get_play_area() const;
 
 
 
@@ -88,21 +100,21 @@ public:
 
 
 	/************************************************************************/
-	/* Utility functions / Glue to ARVRServer */
-	std::vector<ARVRPositionalTracker *> trackers{};
+	/* Utility functions / Glue to XRServer */
+	std::vector<XRPositionalTracker *> trackers{};
 
 	float get_worldscale() {
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		ERR_FAIL_NULL_V(arvr_server, 1.0);
 
 		return arvr_server->get_world_scale();
 	}
 
 	void set_controller_transform(int p_controller_id, Transform *p_transform, bool p_tracks_orientation, bool p_tracks_position) {
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		ERR_FAIL_NULL(arvr_server);
 
-		ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+		XRPositionalTracker *tracker = arvr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
 		if (tracker != NULL) {
 			Transform *transform = (Transform *)p_transform;
 			if (p_tracks_orientation) {
@@ -115,21 +127,21 @@ public:
 	}
 
 	int add_controller(char *p_device_name, int p_hand, bool p_tracks_orientation, bool p_tracks_position) {
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		ERR_FAIL_NULL_V(arvr_server, 0);
 
-		InputDefault *input = (InputDefault *)Input::get_singleton();
+		Input *input = (Input *)Input::get_singleton();
 		ERR_FAIL_NULL_V(input, 0);
 
-		ARVRPositionalTracker *new_tracker = memnew(ARVRPositionalTracker);
+		XRPositionalTracker *new_tracker = memnew(XRPositionalTracker);
 		trackers.push_back(new_tracker);
 
-		new_tracker->set_name(p_device_name);
-		new_tracker->set_type(ARVRServer::TRACKER_CONTROLLER);
+		new_tracker->set_tracker_name(p_device_name);
+		new_tracker->set_tracker_type(XRServer::TRACKER_CONTROLLER);
 		if (p_hand == 1) {
-			new_tracker->set_hand(ARVRPositionalTracker::TRACKER_LEFT_HAND);
+			new_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_LEFT);
 		} else if (p_hand == 2) {
-			new_tracker->set_hand(ARVRPositionalTracker::TRACKER_RIGHT_HAND);
+			new_tracker->set_tracker_hand(XRPositionalTracker::TRACKER_HAND_RIGHT);
 		}
 
 		// also register as joystick...
@@ -156,13 +168,13 @@ public:
 	}
 
 	void remove_controller(int p_controller_id) {
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		ERR_FAIL_NULL(arvr_server);
 
-		InputDefault *input = (InputDefault *)Input::get_singleton();
+		Input *input = (Input *)Input::get_singleton();
 		ERR_FAIL_NULL(input);
 
-		ARVRPositionalTracker *remove_tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+		XRPositionalTracker *remove_tracker = arvr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
 		if (remove_tracker != NULL) {
 			// unset our joystick if applicable
 			int joyid = remove_tracker->get_joy_id();
@@ -178,13 +190,13 @@ public:
 	}
 
 	void set_controller_button(int p_controller_id, int p_button, bool p_is_pressed) {
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		ERR_FAIL_NULL(arvr_server);
 
-		InputDefault *input = (InputDefault *)Input::get_singleton();
+		Input *input = (Input *)Input::get_singleton();
 		ERR_FAIL_NULL(input);
 
-		ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+		XRPositionalTracker *tracker = arvr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
 		if (tracker != NULL) {
 			int joyid = tracker->get_joy_id();
 			if (joyid != -1) {
@@ -194,17 +206,17 @@ public:
 	}
 
 	void set_controller_axis(int p_controller_id, int p_axis, float p_value, float p_can_be_negative) {
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		ERR_FAIL_NULL(arvr_server);
 
-		InputDefault *input = (InputDefault *)Input::get_singleton();
+		Input *input = (Input *)Input::get_singleton();
 		ERR_FAIL_NULL(input);
 
-		ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+		XRPositionalTracker *tracker = arvr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
 		if (tracker != NULL) {
 			int joyid = tracker->get_joy_id();
 			if (joyid != -1) {
-				InputDefault::JoyAxis jx;
+				Input::JoyAxis jx;
 				jx.min = p_can_be_negative ? -1 : 0;
 				jx.value = p_value;
 				input->joy_axis(joyid, p_axis, jx);
@@ -213,10 +225,10 @@ public:
 	}
 
 	float get_controller_rumble(int p_controller_id) {
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		ERR_FAIL_NULL_V(arvr_server, 0.0);
 
-		ARVRPositionalTracker *tracker = arvr_server->find_by_type_and_id(ARVRServer::TRACKER_CONTROLLER, p_controller_id);
+		XRPositionalTracker *tracker = arvr_server->find_by_type_and_id(XRServer::TRACKER_CONTROLLER, p_controller_id);
 		if (tracker != NULL) {
 			return tracker->get_rumble();
 		}
@@ -225,18 +237,18 @@ public:
 	}
 
 	void register_interface() {
-		ARVRServer::get_singleton()->add_interface(this);
+		XRServer::get_singleton()->add_interface(this);
 	}
 
 	void unregister_interface() {
-		ARVRServer::get_singleton()->remove_interface(this);
+		XRServer::get_singleton()->remove_interface(this);
 	}
 
 	Transform get_reference_frame() {
 		Transform reference_frame;
 		Transform *reference_frame_ptr = (Transform *)&reference_frame;
 
-		ARVRServer *arvr_server = ARVRServer::get_singleton();
+		XRServer *arvr_server = XRServer::get_singleton();
 		if (arvr_server != NULL) {
 			*reference_frame_ptr = arvr_server->get_reference_frame();
 		}
@@ -246,30 +258,37 @@ public:
 
 	void blit(int p_eye, RID *p_render_target, Rect2 *p_rect) {
 		// blits out our texture as is, handy for preview display of one of the eyes that is already rendered with lens distortion on an external HMD
-		ARVRInterface::Eyes eye = (ARVRInterface::Eyes)p_eye;
+		XRInterface::Eyes eye = (XRInterface::Eyes)p_eye;
 		RID *render_target = (RID *)p_render_target;
 		Rect2 screen_rect = *(Rect2 *)p_rect;
 
-		if (eye == ARVRInterface::EYE_LEFT) {
+		if (eye == XRInterface::EYE_LEFT) {
 			screen_rect.size.x /= 2.0;
-		} else if (p_eye == ARVRInterface::EYE_RIGHT) {
+		} else if (p_eye == XRInterface::EYE_RIGHT) {
 			screen_rect.size.x /= 2.0;
 			screen_rect.position.x += screen_rect.size.x;
 		}
 
-		VSG::rasterizer->set_current_render_target(RID());
-		VSG::rasterizer->blit_render_target_to_screen(*render_target, screen_rect, 0);
+		/* THIS BIT NEEDS REDONE
+		RSG::rasterizer->set_current_render_target(RID());
+		RSG::rasterizer->blit_render_target_to_screen(*render_target, screen_rect, 0);
+		*/
+
 	}
 
-	int get_texid(RID *p_render_target) {
+	uint32_t get_texid(RID *p_render_target) {
 		// In order to send off our textures to display on our hardware we need the opengl texture ID instead of the render target RID
 		// This is a handy function to expose that.
-		RID *render_target = (RID *)p_render_target;
 
-		RID eye_texture = VSG::storage->render_target_get_texture(*render_target);
-		uint32_t texid = VS::get_singleton()->texture_get_texid(eye_texture);
+		// need to redo this
 
-		return texid;
+	/*	RID *render_target = (RID *)p_render_target;
+
+		RID eye_texture = RSG::storage->render_target_get_texture(*render_target);
+		uint32_t texid = RS::get_singleton()->texture_get_texid(eye_texture);
+
+		return texid;*/
+		return 0;
 	}
 };
 

--- a/src/openvr/OpenVRInterface.h
+++ b/src/openvr/OpenVRInterface.h
@@ -252,26 +252,6 @@ public:
 
 		return reference_frame;
 	}
-
-	void blit(int p_eye, RID *p_render_target, Rect2 *p_rect) {
-		// blits out our texture as is, handy for preview display of one of the eyes that is already rendered with lens distortion on an external HMD
-		XRInterface::Eyes eye = (XRInterface::Eyes)p_eye;
-		RID *render_target = p_render_target;
-		Rect2 screen_rect = *p_rect;
-
-		if (eye == XRInterface::EYE_LEFT) {
-			screen_rect.size.x /= 2.0;
-		} else if (p_eye == XRInterface::EYE_RIGHT) {
-			screen_rect.size.x /= 2.0;
-			screen_rect.position.x += screen_rect.size.x;
-		}
-
-		RSG::rasterizer->prepare_for_blitting_render_targets();
-		RendererCompositor::BlitToScreen blit;
-		blit.render_target = *p_render_target;
-		blit.rect = Rect2i(*p_rect);
-		RSG::rasterizer->blit_render_targets_to_screen(0, &blit, 1);
-	}
 };
 
 #endif

--- a/src/openvr/OpenVRInterface.h
+++ b/src/openvr/OpenVRInterface.h
@@ -65,7 +65,6 @@ public:
 	void fill_projection_for_eye(float *p_projection, int p_eye, float p_aspect, float p_z_near, float p_z_far);
 	CameraMatrix get_projection_for_eye(XRInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far) override; /* get each eyes projection matrix */
 	unsigned int get_external_texture_for_eye(XRInterface::Eyes p_eye) override; /* if applicable return external texture to render to */
-	void commit_for_eye(XRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) override; /* output the left or right eye */
 
 	void process() override;
 	void notification(int p_what) override;

--- a/src/openvr/OpenVROverlay.cpp
+++ b/src/openvr/OpenVROverlay.cpp
@@ -1,7 +1,16 @@
 #include "OpenVROverlay.h"
 #include "OpenVRInterface.h"
-#include <servers/arvr_server.h>
-#include <core/engine.h>
+#include <servers/xr_server.h>
+#include <core/config/engine.h>
+#include <core/version.h>
+
+#if(VERSION_MAJOR) >= 4
+	#define TEXTURE_CLASS Texture2D
+	#define REAL_VARIANT Variant::FLOAT
+#else
+	#define TEXTURE_CLASS Texture
+	#define REAL_VARIANT Variant::REAL
+#endif
 
 void OpenVROverlay::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_exit_tree"), &OpenVROverlay::_exit_tree);
@@ -12,7 +21,7 @@ void OpenVROverlay::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_overlay_width_in_meters"), &OpenVROverlay::get_overlay_width_in_meters);
 	ClassDB::bind_method(D_METHOD("set_overlay_width_in_meters"), &OpenVROverlay::set_overlay_width_in_meters);
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "overlay_width_in_meters", PROPERTY_HINT_NONE), "set_overlay_width_in_meters", "get_overlay_width_in_meters");
+	ADD_PROPERTY(PropertyInfo(REAL_VARIANT, "overlay_width_in_meters", PROPERTY_HINT_NONE), "set_overlay_width_in_meters", "get_overlay_width_in_meters");
 
 	ClassDB::bind_method(D_METHOD("track_relative_to_device"), &OpenVROverlay::track_relative_to_device);
 	ClassDB::bind_method(D_METHOD("overlay_position_absolute"), &OpenVROverlay::overlay_position_absolute);
@@ -23,7 +32,7 @@ OpenVROverlay::OpenVROverlay() {
 	overlay_width_in_meters = 1.0;
 	overlay_visible = true;
 
-	set_update_mode(Viewport::UpdateMode::UPDATE_ALWAYS);
+	set_update_mode(SubViewport::UpdateMode::UPDATE_ALWAYS);
 }
 
 OpenVROverlay::~OpenVROverlay() {
@@ -57,7 +66,7 @@ void OpenVROverlay::_ready() {
 	overlay_position_absolute(initial_transform);
 	set_overlay_width_in_meters(overlay_width_in_meters);
 	set_overlay_visible(overlay_visible);
-	set_use_arvr(true);
+	set_use_xr(true);
 }
 
 void OpenVROverlay::_exit_tree() {
@@ -133,7 +142,7 @@ void OpenVROverlay::set_overlay_visible(bool p_visible) {
 bool OpenVROverlay::track_relative_to_device(vr::TrackedDeviceIndex_t p_tracked_device_index, Transform p_transform) {
 	if (overlay && !Engine::get_singleton()->is_editor_hint()) {
 		vr::HmdMatrix34_t matrix;
-		Ref<OpenVRInterface> ovr_interface = static_cast<Ref<OpenVRInterface> >(ARVRServer::get_singleton()->find_interface("OpenVR"));
+		Ref<OpenVRInterface> ovr_interface = static_cast<Ref<OpenVRInterface> >(XRServer::get_singleton()->find_interface("OpenVR"));
 		ovr->matrix_from_transform(&matrix, (Transform *)&p_transform, ovr_interface->get_worldscale());
 
 		vr::EVROverlayError vrerr = vr::VROverlay()->SetOverlayTransformTrackedDeviceRelative(overlay, p_tracked_device_index, &matrix);
@@ -153,7 +162,7 @@ bool OpenVROverlay::overlay_position_absolute(Transform p_transform) {
 	if (overlay && !Engine::get_singleton()->is_editor_hint()) {
 		vr::HmdMatrix34_t matrix;
 		vr::TrackingUniverseOrigin origin;
-		Ref<OpenVRInterface> ovr_interface = static_cast<Ref<OpenVRInterface> >(ARVRServer::get_singleton()->find_interface("OpenVR"));
+		Ref<OpenVRInterface> ovr_interface = static_cast<Ref<OpenVRInterface>>(XRServer::get_singleton()->find_interface("OpenVR"));
 		ovr->matrix_from_transform(&matrix, (Transform *)&p_transform, ovr_interface->get_worldscale());
 
 		openvr_data::OpenVRTrackingUniverse tracking_universe = ovr->get_tracking_universe();

--- a/src/openvr/OpenVROverlay.h
+++ b/src/openvr/OpenVROverlay.h
@@ -4,8 +4,8 @@
 #include <scene/main/viewport.h>
 #include "openvr_data.h"
 
-class OpenVROverlay : public Viewport {
-	GDCLASS(OpenVROverlay, Viewport)
+class OpenVROverlay : public SubViewport {
+	GDCLASS(OpenVROverlay, SubViewport)
 
 private:
 	openvr_data *ovr;

--- a/src/openvr/OpenVRPose.cpp
+++ b/src/openvr/OpenVRPose.cpp
@@ -24,7 +24,7 @@ void OpenVRPose::_process(float delta) {
 
 		if (is_active) {
 			// printf("Pose is active\n");
-			Ref<OpenVRInterface> ovr_interface = static_cast<Ref<OpenVRInterface> >(ARVRServer::get_singleton()->find_interface("OpenVR"));
+			Ref<OpenVRInterface> ovr_interface = static_cast<Ref<OpenVRInterface>>(XRServer::get_singleton()->find_interface("OpenVR"));
 			float world_scale = ovr_interface->get_worldscale();
 			Transform transform;
 			ovr->transform_from_matrix(&transform, &pose_data.pose.mDeviceToAbsoluteTracking, world_scale);
@@ -37,7 +37,7 @@ void OpenVRPose::_process(float delta) {
 
 OpenVRPose::OpenVRPose() {
 	ovr = openvr_data::retain_singleton();
-	server = ARVRServer::get_singleton();
+	server = XRServer::get_singleton();
 	action_idx = -1;
 	is_active = false;
 	on_hand = 0;

--- a/src/openvr/OpenVRPose.h
+++ b/src/openvr/OpenVRPose.h
@@ -2,15 +2,15 @@
 #define OPENVR_POSE_H
 
 #include "openvr_data.h"
-#include <servers/arvr_server.h>
-#include <scene/3d/spatial.h>
+#include <servers/xr_server.h>
+#include <scene/3d/node_3d.h>
 
-class OpenVRPose : public Spatial {
-	GDCLASS(OpenVRPose, Spatial)
+class OpenVRPose : public Node3D {
+	GDCLASS(OpenVRPose, Node3D)
 
 private:
 	openvr_data *ovr;
-	ARVRServer *server;
+	XRServer *server;
 
 	String action;
 	int action_idx;

--- a/src/openvr/OpenVRRenderModel.cpp
+++ b/src/openvr/OpenVRRenderModel.cpp
@@ -35,11 +35,7 @@ Array OpenVRRenderModel::model_names() {
 bool OpenVRRenderModel::load_model(String p_model_name) {
 	bool success = true;
 
-	int64_t surfaces = get_surface_count();
-	for (int64_t s = 0; s < surfaces; s++) {
-		// keep removing the first surface, for all the surfaces we have
-		surface_remove(0);
-	}
+	clear_surfaces();
 
 	print_line("Loading: " + p_model_name);
 	ovr->load_render_model(p_model_name, this);

--- a/src/openvr/OpenVRSkeleton.h
+++ b/src/openvr/OpenVRSkeleton.h
@@ -2,12 +2,12 @@
 #define OPENVR_SKELETON_H
 
 #include "openvr_data.h"
-#include <scene/3d/skeleton.h>
+#include <scene/3d/skeleton_3d.h>
 
 #include <stdlib.h>
 
-class OpenVRSkeleton : public Skeleton {
-	GDCLASS(OpenVRSkeleton, Skeleton)
+class OpenVRSkeleton : public Skeleton3D {
+	GDCLASS(OpenVRSkeleton, Skeleton3D)
 
 private:
 	openvr_data *ovr;

--- a/src/openvr/openvr_data.cpp
+++ b/src/openvr/openvr_data.cpp
@@ -41,7 +41,7 @@ openvr_data::~openvr_data() {
 void openvr_data::cleanup() {
 
 	if (image.is_valid()) {
-		image = nullptr;
+		image.unref();
 	}
 
 	if (hmd != NULL) {
@@ -217,7 +217,7 @@ bool openvr_data::initialise() {
 			print_line(String("Failed to find action file"));
 		}
 
-		directory = nullptr;
+		directory.unref();
 	}
 
 	if (success) {
@@ -1215,7 +1215,7 @@ bool openvr_data::_load_texture(texture_material *p_texture) {
 
 	// reset our references to ensure our material gets freed at the right time
 	p_texture->material = Ref<StandardMaterial3D>();
-	texture = nullptr;
+	texture.unref();
 	return true;
 }
 

--- a/src/openvr/openvr_data.cpp
+++ b/src/openvr/openvr_data.cpp
@@ -524,7 +524,7 @@ void openvr_data::get_eye_to_head_transform(Transform *p_transform, int p_eye, f
 		return;
 	}
 
-	vr::HmdMatrix34_t matrix = hmd->GetEyeToHeadTransform(p_eye == 1 ? vr::Eye_Left : vr::Eye_Right);
+	vr::HmdMatrix34_t matrix = hmd->GetEyeToHeadTransform(p_eye == XRInterface::EYE_LEFT ? vr::Eye_Left : vr::Eye_Right);
 
 	transform_from_matrix(p_transform, &matrix, p_world_scale);
 }

--- a/src/openvr/openvr_data.cpp
+++ b/src/openvr/openvr_data.cpp
@@ -2,8 +2,8 @@
 // Helper calls and singleton container for accessing openvr
 
 #include "openvr_data.h"
-#include <core/bind/core_bind.h>
-#include <core/project_settings.h>
+#include <core/core_bind.h>
+#include <core/config/project_settings.h>
 #include "OpenVRInterface.h"
 
 openvr_data *openvr_data::singleton = NULL;
@@ -289,7 +289,7 @@ void openvr_data::process() {
 	uint64_t msec = _OS::get_singleton()->get_ticks_msec();
 
 	// we scale all our positions by our world scale
-	Ref<OpenVRInterface> server = ARVRServer::get_singleton()->find_interface("OpenVR");
+	Ref<OpenVRInterface> server = XRServer::get_singleton()->find_interface("OpenVR");
 
 	if (!server.is_valid()) {
 		return;
@@ -390,7 +390,7 @@ void openvr_data::process() {
 				Transform transform;
 				transform_from_matrix(&transform, &tracked_device_pose[i].mDeviceToAbsoluteTracking, 1.0);
 
-				Ref<OpenVRInterface> server = ARVRServer::get_singleton()->find_interface("OpenVR");
+				Ref<OpenVRInterface> server = XRServer::get_singleton()->find_interface("OpenVR");
 
 				if (!server.is_valid()) {
 					continue;
@@ -886,7 +886,7 @@ void openvr_data::attach_device(uint32_t p_device_index) {
 
 			sprintf(&device_name[strlen(device_name)], "_%i", p_device_index);
 
-			Ref<OpenVRInterface> server = ARVRServer::get_singleton()->find_interface("OpenVR");
+			Ref<OpenVRInterface> server = XRServer::get_singleton()->find_interface("OpenVR");
 
 			if (server.is_valid()) {
 				device->tracker_id = server->add_controller(device_name, hand, true, true);
@@ -913,7 +913,7 @@ void openvr_data::detach_device(uint32_t p_device_index) {
 	if (p_device_index == vr::k_unTrackedDeviceIndexInvalid) {
 		// really?!
 	} else if (tracked_devices[p_device_index].tracker_id != 0) {
-		Ref<OpenVRInterface> server = ARVRServer::get_singleton()->find_interface("OpenVR");
+		Ref<OpenVRInterface> server = XRServer::get_singleton()->find_interface("OpenVR");
 
 		if (server.is_valid()) {
 			server->remove_controller(tracked_devices[p_device_index].tracker_id);
@@ -932,7 +932,7 @@ void openvr_data::detach_device(uint32_t p_device_index) {
 ////////////////////////////////////////////////////////////////
 // Called by our process loop to handle our fixed actions
 void openvr_data::process_device_actions(tracked_device *p_device, uint64_t p_msec) {
-	Ref<OpenVRInterface> server = ARVRServer::get_singleton()->find_interface("OpenVR");
+	Ref<OpenVRInterface> server = XRServer::get_singleton()->find_interface("OpenVR");
 	const char input_types[DAH_IN_MAX] = { 'b', 'f', 'b', 'f', 'v', 'b', 'b', 'b' }; // input type (b)oolean, (f)loat, (v)ector2
 	const int godot_index[DAH_IN_MAX] = { 15, 2, 2, 4, 0, 14, 7, 1 }; // button / axis indexes
 
@@ -1085,10 +1085,10 @@ bool openvr_data::_load_render_model(model_mesh *p_model) {
 		return true;
 	}
 
-	PoolVector3Array vertices;
-	PoolVector3Array normals;
-	PoolVector2Array texcoords;
-	PoolIntArray indices;
+	PackedVector3Array vertices;
+	PackedVector3Array normals;
+	PackedVector2Array texcoords;
+	Vector<int> indices;
 	Array arr;
 	Array blend_array;
 
@@ -1101,9 +1101,9 @@ bool openvr_data::_load_render_model(model_mesh *p_model) {
 	// copy our vertices
 	{
 		// lock for writing
-		PoolVector3Array::Write vw = vertices.write();
-		PoolVector3Array::Write nw = normals.write();
-		PoolVector2Array::Write tw = texcoords.write();
+		Vector3 *vw = vertices.ptrw();
+		Vector3 * nw = normals.ptrw();
+		Vector2 * tw = texcoords.ptrw();
 
 		for (uint32_t i = 0; i < ovr_render_model->unVertexCount; i++) {
 			vw[i] = Vector3(ovr_render_model->rVertexData[i].vPosition.v[0], ovr_render_model->rVertexData[i].vPosition.v[1], ovr_render_model->rVertexData[i].vPosition.v[2]);
@@ -1115,7 +1115,7 @@ bool openvr_data::_load_render_model(model_mesh *p_model) {
 	// copy our indices, for some reason these are other way around :)
 	{
 		// lock for writing
-		PoolIntArray::Write iw = indices.write();
+		int* iw = indices.ptrw();
 
 		for (uint32_t i = 0; i < ovr_render_model->unTriangleCount * 3; i += 3) {
 			iw[i + 0] = ovr_render_model->rIndexData[i + 2];
@@ -1134,10 +1134,10 @@ bool openvr_data::_load_render_model(model_mesh *p_model) {
 	arr[ArrayMesh::ARRAY_INDEX] = indices;
 
 	// and load
-	p_model->mesh->add_surface_from_arrays(ArrayMesh::PRIMITIVE_TRIANGLES, arr, blend_array, ArrayMesh::ARRAY_COMPRESS_DEFAULT);
+	p_model->mesh->add_surface_from_arrays(Mesh::PrimitiveType::PRIMITIVE_TRIANGLES, arr, blend_array);
 
 	// prepare our material
-	Ref<SpatialMaterial> material;
+	Ref<StandardMaterial3D> material;
 	material.instance();
 
 	// queue loading our textures
@@ -1155,7 +1155,7 @@ bool openvr_data::_load_render_model(model_mesh *p_model) {
 
 ////////////////////////////////////////////////////////////////
 // Load a texture and load it into a spatial material
-void openvr_data::load_texture(TextureType p_type, vr::TextureID_t p_texture_id, Ref<SpatialMaterial> p_material) {
+void openvr_data::load_texture(TextureType p_type, vr::TextureID_t p_texture_id, Ref<StandardMaterial3D> p_material) {
 	// add an entry, we'll attempt a load
 	texture_material new_entry;
 
@@ -1185,18 +1185,18 @@ bool openvr_data::_load_texture(texture_material *p_texture) {
 		print_line(String("OpenVR: Couldn''t find texture for ") + String::num_int64(p_texture->texture_id) + " (" + String::num_int64(err) + ")");
 
 		// reset our references to ensure our material gets freed at the right time
-		p_texture->material = Ref<SpatialMaterial>();
+		p_texture->material = Ref<StandardMaterial3D>();
 
 		// don't try again, remove it from our list
 		return true;
 	}
 
-	PoolByteArray image_data;
+	Vector<uint8_t> image_data;
 	image_data.resize(ovr_texture->unWidth * ovr_texture->unHeight * 4);
 
 	{
-		PoolByteArray::Write idw = image_data.write();
-		memcpy(idw.ptr(), ovr_texture->rubTextureMapData, ovr_texture->unWidth * ovr_texture->unHeight * 4);
+		uint8_t* idw = image_data.ptrw();
+		memcpy(idw, ovr_texture->rubTextureMapData, ovr_texture->unWidth * ovr_texture->unHeight * 4);
 	}
 
 	image = static_cast<Ref<Image>>(memnew(Image));
@@ -1204,17 +1204,17 @@ bool openvr_data::_load_texture(texture_material *p_texture) {
 	image->create(ovr_texture->unWidth, ovr_texture->unHeight, false, Image::FORMAT_RGBA8, image_data);
 
 	Ref<ImageTexture> texture = memnew(ImageTexture);
-	texture->create_from_image(image, 7);
+	texture->create_from_image(image);
 
 	switch (p_texture->type) {
 		case TT_ALBEDO:
-			p_texture->material->set_texture(SpatialMaterial::TEXTURE_ALBEDO, texture);
+			p_texture->material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, texture);
 			break;
 		default: break;
 	}
 
 	// reset our references to ensure our material gets freed at the right time
-	p_texture->material = Ref<SpatialMaterial>();
+	p_texture->material = Ref<StandardMaterial3D>();
 	texture = nullptr;
 	return true;
 }

--- a/src/openvr/openvr_data.h
+++ b/src/openvr/openvr_data.h
@@ -7,6 +7,7 @@
 #include <openvr.h>
 #include <scene/resources/mesh.h>
 #include <vector>
+#include <core/templates/vector.h>
 
 class openvr_data {
 public:
@@ -136,12 +137,12 @@ private:
 	struct texture_material {
 		TextureType type;
 		vr::TextureID_t texture_id;
-		Ref<SpatialMaterial> material;
+		Ref<StandardMaterial3D> material;
 	};
 
 	std::vector<texture_material> load_textures;
 
-	void load_texture(TextureType p_type, vr::TextureID_t p_texture_id, Ref<SpatialMaterial> p_material);
+	void load_texture(TextureType p_type, vr::TextureID_t p_texture_id, Ref<StandardMaterial3D> p_material);
 	bool _load_texture(texture_material *p_texture);
 
 public:

--- a/src/openvr/openvr_data.h
+++ b/src/openvr/openvr_data.h
@@ -4,7 +4,7 @@
 #ifndef GDOPENVR_DATA_H
 #define GDOPENVR_DATA_H
 
-#include <openvr.h>
+#include "modules/gdopenvr/lib/openvr/headers/openvr.h"
 #include <scene/resources/mesh.h>
 #include <vector>
 #include <core/templates/vector.h>


### PR DESCRIPTION
Alternative approach.

`git clone https://github.com/godot-extended-libraries/godot-fire -b  master-openvr`.

`git clone https://github.com/mauville-technologies/gdopenvr.git -b master-rd`

Build with custom_modules set to this repo. Similar to `scons p=windows -j16 custom_modules=../modules`

`git clone https://github.com/Ozzadar/Godot4OVRTest.git`

Currently only renders on one eye. Expected two to render correctly. One viewport render to texture is created while two are needed.

![image](https://user-images.githubusercontent.com/32321/103891472-c1b74380-509e-11eb-9536-b3531d907ed6.png)

Todo:

* Move commit_for_eye to a function pointer in each of the vr modules
* Convert to openxr.
* Move to a texture array approach
* Add variable rate shading